### PR TITLE
Fix so the script will print the usage on no arguments given. See #42 for parant issue

### DIFF
--- a/bin/hedgedoc
+++ b/bin/hedgedoc
@@ -413,6 +413,11 @@ function main() {
     esac
 }
 
+# Do the usage function of no Command line arguments are given.
+if [[ $# -eq 0 [[; then
+  set -- "help"
+fi  
+
 # Allow importing funcs without running main by using `source ./bin/hedgedoc --import`
 if [[ "${1:-}" != "--import" ]]; then
     main "$@" || exit $?

--- a/bin/hedgedoc
+++ b/bin/hedgedoc
@@ -414,7 +414,7 @@ function main() {
 }
 
 # Do the usage function of no Command line arguments are given.
-if [[ $# -eq 0 [[; then
+if [[ $# -eq 0 ]]; then
   set -- "help"
 fi  
 


### PR DESCRIPTION
This small addition will make the script check the number of arguments given, and if none are given set the argument to `help` so the usage will be printed. if the import is used as documented in the file in my test it did not trigger this code.

see: 
https://github.com/hedgedoc/cli/issues/42