### PR TITLE
Add backup cli command, exporting all notes for current user

### DIFF
--- a/bin/hedgedoc
+++ b/bin/hedgedoc
@@ -77,7 +77,7 @@ Config:
     \$HEDGEDOC_CONFIG_DIR   (defaults to $XDG_CONFIG_HOME/$SCRIPTNAME)
     \$HEDGEDOC_COOKIES_FILE (defaults to \$HEDGEDOC_CONFIG_DIR/key.conf)
 
-Usage examples: 
+Usage examples:
 
     \$ export HEDGEDOC_SERVER='$HEDGEDOC_SERVER'
     \$ export HEDGEDOC_COOKIES_FILE=$HEDGEDOC_COOKIES_FILE
@@ -174,7 +174,7 @@ function import_note() {
         echo "Hint: You may need to run '$SCRIPTNAME login' to authenticate first." >&2
         return 2
     fi
-    echo "$note_id" 
+    echo "$note_id"
 }
 
 function export_note() {
@@ -230,7 +230,7 @@ function export_note() {
             output_path="${output_path:-$note_id.zip}"
             # hack: there is no way to get slide output as zipfile directly.
             #       we dump it to folder of html files first then zip it.
-            
+
             # check for any existing conflicting file/dir that wget downloads
             local temp_folder_name="$(
                 echo "$HEDGEDOC_SERVER" \
@@ -257,6 +257,17 @@ function export_note() {
             return 2
             ;;
     esac
+}
+
+function backup_all_notes() {
+    output_path="${1:-archive.zip}"
+
+    curl \
+        --silent \
+        --cookie "$HEDGEDOC_COOKIES_FILE" \
+        --output "$output_path" \
+        "${HEDGEDOC_SERVER}/me/export" \
+    && echo "$output_path"
 }
 
 function user_login() {
@@ -349,7 +360,7 @@ function user_profile() {
 
 function user_history() {
     assert_is_authenticated
-    
+
     curl \
         --silent \
         --cookie "$HEDGEDOC_COOKIES_FILE" \
@@ -390,6 +401,9 @@ function main() {
         export)
             export_note "${1:-}" "${2:-}" "${3:-}"
             ;;
+        backup)
+            backup_all_notes "${1:-}"
+            ;;
         delete)
             delete_note "${1:-}"
             ;;
@@ -416,7 +430,7 @@ function main() {
 # Do the usage function of no Command line arguments are given.
 if [[ $# -eq 0 ]]; then
   set -- "help"
-fi  
+fi
 
 # Allow importing funcs without running main by using `source ./bin/hedgedoc --import`
 if [[ "${1:-}" != "--import" ]]; then


### PR DESCRIPTION
The hedgedoc API has an endpoint to export a ZIP archive of all notes for the user.

This pull request adds acess to that API endpoint as 'backup' command, since the export command is already used to export a single note.

Since this CLI only interacts with the API, I'd argue that 'backup' is fine as a name, and wont be confused with a proper backup command that would create a database dump & archive with all the uploads